### PR TITLE
Remove unused localizr

### DIFF
--- a/app/templates/common/kraken/package.json
+++ b/app/templates/common/kraken/package.json
@@ -13,7 +13,6 @@
     "construx": "~0.0.1",
     "construx-copier": "~0.0.1",
     "kraken-js": "^1.0.1",
-    "localizr": "^0.1.6",
     "node-jsx": "^0.13.3",
     "react": "^15.1.0",
     "react-dom": "^15.1.0",


### PR DESCRIPTION
[`localizr`](https://www.npmjs.com/package/localizr) is a library and tool to apply localization to `dust` templates before rendering.
But we are using `ReactJS` and not the DustJS here. So it is unused.
